### PR TITLE
fix race conditions

### DIFF
--- a/lib/orm_proxy.rb
+++ b/lib/orm_proxy.rb
@@ -23,9 +23,11 @@ class ORMProxy
   def update_db
     record = model_klass.find_by_id(attributes['id'])
     if record
-      unless skip_update?(record)
-        attributes.delete('id')
-        update_record(record, attributes)
+      record.with_lock do
+        unless skip_update?(record)
+          attributes.delete('id')
+          update_record(record, attributes)
+        end
       end
     else
       create_record(model_klass, attributes)

--- a/lib/orm_proxy.rb
+++ b/lib/orm_proxy.rb
@@ -23,8 +23,10 @@ class ORMProxy
   def update_db
     record = model_klass.find_by_id(attributes['id'])
     if record
-      attributes.delete('id')
-      update_record(record, attributes)
+      unless skip_update?(record)
+        attributes.delete('id')
+        update_record(record, attributes)
+      end
     else
       create_record(model_klass, attributes)
     end
@@ -65,6 +67,10 @@ class ORMProxy
   end
 
   private
+
+  def skip_update?(record)
+    record.respond_to?(:updated_at) && attributes.has_key?('updated_at') && record.updated_at > Time.parse(attributes['updated_at'])
+  end
 
   def model_key
     model_name.singularize.foreign_key

--- a/spec/orm_proxy/active_record4_spec.rb
+++ b/spec/orm_proxy/active_record4_spec.rb
@@ -27,6 +27,7 @@ describe ORMProxy::ActiveRecord4 do
 
         it "updates record" do
           expect(Shop).to receive(:find_by_id).with(1).and_return(record)
+          expect(record).to receive(:with_lock).and_yield
           expect(record).to receive(:respond_to?).and_return(true)
           expect(record).to receive(:updated_at).and_return(Time.now - 5*60)
           expect(record).to receive(:update_attributes).with(attrs_for_update)
@@ -39,6 +40,7 @@ describe ORMProxy::ActiveRecord4 do
 
           it "skips outdated record update" do
             expect(Shop).to receive(:find_by_id).with(1).and_return(record)
+            expect(record).to receive(:with_lock).and_yield
             expect(record).to receive(:respond_to?).and_return(true)
             expect(record).to receive(:updated_at).and_return(Time.now)
             expect(record).not_to receive(:update_attributes)
@@ -56,6 +58,7 @@ describe ORMProxy::ActiveRecord4 do
 
         before do
           expect(Shop).to receive(:find_by_id).with(1).and_return(record)
+          expect(record).to receive(:with_lock).and_yield
           expect(record).to receive(:update_attributes).with(attrs_for_update)
         end
 

--- a/spec/orm_proxy/active_record4_spec.rb
+++ b/spec/orm_proxy/active_record4_spec.rb
@@ -4,8 +4,9 @@ describe ORMProxy::ActiveRecord4 do
 
   describe "#update_db" do
     let(:model)  { 'shops' }
-    let(:attributes) { {'id' => 1, 'name' => 'test'} }
-    let(:attrs_for_update) { {'name' => 'test'} }
+    let(:updated_at) { Time.now.to_s }
+    let(:attributes) { {'id' => 1, 'name' => 'test', 'updated_at' => updated_at} }
+    let(:attrs_for_update) { {'name' => 'test', 'updated_at' => updated_at} }
 
     let(:proxy) { described_class.new(model, attributes) }
 
@@ -26,9 +27,24 @@ describe ORMProxy::ActiveRecord4 do
 
         it "updates record" do
           expect(Shop).to receive(:find_by_id).with(1).and_return(record)
+          expect(record).to receive(:respond_to?).and_return(true)
+          expect(record).to receive(:updated_at).and_return(Time.now - 5*60)
           expect(record).to receive(:update_attributes).with(attrs_for_update)
 
           proxy.update_db
+        end
+
+        context "and there outedated update" do
+          let(:updated_at) { (Time.now - 10).to_s }
+
+          it "skips outdated record update" do
+            expect(Shop).to receive(:find_by_id).with(1).and_return(record)
+            expect(record).to receive(:respond_to?).and_return(true)
+            expect(record).to receive(:updated_at).and_return(Time.now)
+            expect(record).not_to receive(:update_attributes)
+
+            proxy.update_db
+          end
         end
       end
 
@@ -36,7 +52,7 @@ describe ORMProxy::ActiveRecord4 do
         class BrandsShop; end
 
         let(:record) { double('record', id: 1) }
-        let(:attributes) { {'id' => 1, 'name' => 'test', '_adds' => {'habtms' => {'brands' => ['1', '2']}}} }
+        let(:attributes) { {'id' => 1, 'name' => 'test', 'updated_at' => updated_at, '_adds' => {'habtms' => {'brands' => ['1', '2']}}} }
 
         before do
           expect(Shop).to receive(:find_by_id).with(1).and_return(record)
@@ -55,7 +71,7 @@ describe ORMProxy::ActiveRecord4 do
       context "when _model_name attribute present" do
         class NewModel; end
 
-        let(:attributes) { { 'id' => 1, 'name' => 'test', '_model_name' => 'NewModel' } }
+        let(:attributes) { { 'id' => 1, 'name' => 'test', 'updated_at' => updated_at, '_model_name' => 'NewModel' } }
 
         it "uses passed model name as model class" do
           expect(NewModel).to receive(:find_by_id).with(1).and_return(nil)

--- a/spec/orm_proxy/active_record_spec.rb
+++ b/spec/orm_proxy/active_record_spec.rb
@@ -27,6 +27,7 @@ describe ORMProxy::ActiveRecord do
 
         it "updates record" do
           expect(Shop).to receive(:find_by_id).with(1).and_return(record)
+          expect(record).to receive(:with_lock).and_yield
           expect(record).to receive(:respond_to?).and_return(true)
           expect(record).to receive(:updated_at).and_return(Time.now - 5*60)
           expect(record).to receive(:update_attributes).with(attrs_for_update, without_protection: true)
@@ -39,6 +40,7 @@ describe ORMProxy::ActiveRecord do
 
           it "skips outdated record update" do
             expect(Shop).to receive(:find_by_id).with(1).and_return(record)
+            expect(record).to receive(:with_lock).and_yield
             expect(record).to receive(:respond_to?).and_return(true)
             expect(record).to receive(:updated_at).and_return(Time.now)
             expect(record).not_to receive(:update_attributes)
@@ -56,6 +58,7 @@ describe ORMProxy::ActiveRecord do
 
         before do
           expect(Shop).to receive(:find_by_id).with(1).and_return(record)
+          expect(record).to receive(:with_lock).and_yield
           expect(record).to receive(:update_attributes).with(attrs_for_update, without_protection: true)
         end
 

--- a/spec/orm_proxy/active_record_spec.rb
+++ b/spec/orm_proxy/active_record_spec.rb
@@ -4,8 +4,9 @@ describe ORMProxy::ActiveRecord do
 
   describe "#update_db" do
     let(:model)  { 'shops' }
-    let(:attributes) { {'id' => 1, 'name' => 'test'} }
-    let(:attrs_for_update) { {'name' => 'test'} }
+    let(:updated_at) { Time.now.to_s }
+    let(:attributes) { {'id' => 1, 'name' => 'test', 'updated_at' => updated_at} }
+    let(:attrs_for_update) { {'name' => 'test', 'updated_at' => updated_at} }
 
     let(:proxy) { described_class.new(model, attributes) }
 
@@ -26,9 +27,24 @@ describe ORMProxy::ActiveRecord do
 
         it "updates record" do
           expect(Shop).to receive(:find_by_id).with(1).and_return(record)
+          expect(record).to receive(:respond_to?).and_return(true)
+          expect(record).to receive(:updated_at).and_return(Time.now - 5*60)
           expect(record).to receive(:update_attributes).with(attrs_for_update, without_protection: true)
 
           proxy.update_db
+        end
+
+        context "and there outedated update" do
+          let(:updated_at) { (Time.now - 10).to_s }
+
+          it "skips outdated record update" do
+            expect(Shop).to receive(:find_by_id).with(1).and_return(record)
+            expect(record).to receive(:respond_to?).and_return(true)
+            expect(record).to receive(:updated_at).and_return(Time.now)
+            expect(record).not_to receive(:update_attributes)
+
+            proxy.update_db
+          end
         end
       end
 
@@ -36,7 +52,7 @@ describe ORMProxy::ActiveRecord do
         class BrandsShop; end
 
         let(:record) { double('record', id: 1) }
-        let(:attributes) { {'id' => 1, 'name' => 'test', '_adds' => {'habtms' => {'brands' => ['1', '2']}}} }
+        let(:attributes) { {'id' => 1, 'name' => 'test', 'updated_at' => updated_at, '_adds' => {'habtms' => {'brands' => ['1', '2']}}} }
 
         before do
           expect(Shop).to receive(:find_by_id).with(1).and_return(record)
@@ -55,7 +71,7 @@ describe ORMProxy::ActiveRecord do
       context "when _model_name attribute present" do
         class NewModel; end
 
-        let(:attributes) { { 'id' => 1, 'name' => 'test', '_model_name' => 'NewModel' } }
+        let(:attributes) { { 'id' => 1, 'name' => 'test', 'updated_at' => updated_at, '_model_name' => 'NewModel' } }
 
         it "uses passed model name as model class" do
           expect(NewModel).to receive(:find_by_id).with(1).and_return(nil)

--- a/spec/orm_proxy_spec.rb
+++ b/spec/orm_proxy_spec.rb
@@ -74,7 +74,7 @@ describe ORMProxy do
     context "when model responds to 'column_names'" do
       class Shop
         def self.column_names
-          ['id', 'name']
+          ['id', 'name', 'updated_at']
         end
       end
 


### PR DESCRIPTION
When there are many updates in a row there can be a data race so later updates could be processed earlier.
To prevent this we can check the `updated_at` column (if provided) to ensure we don't override data.